### PR TITLE
Some additional info output on hard test case and bug fixes on soft test case

### DIFF
--- a/Makefile.rule
+++ b/Makefile.rule
@@ -35,8 +35,8 @@
 # CORTEX_A7  : machine with ARMv7a processor with VPFv3 (D32 versions) and NEON, code optimized for ARM Cortex A7.
 # C99_4X4    : c99 reference code, performing better on a machine with at least 32 scalar registers.
 #TARGET = X64_AVX2
-#TARGET = X64_AVX
-TARGET = X64_SSE3
+TARGET = X64_AVX
+#TARGET = X64_SSE3
 #TARGET = CORTEX_A57
 #TARGET = CORTEX_A15
 #TARGET = CORTEX_A9

--- a/Makefile.rule
+++ b/Makefile.rule
@@ -35,8 +35,8 @@
 # CORTEX_A7  : machine with ARMv7a processor with VPFv3 (D32 versions) and NEON, code optimized for ARM Cortex A7.
 # C99_4X4    : c99 reference code, performing better on a machine with at least 32 scalar registers.
 #TARGET = X64_AVX2
-TARGET = X64_AVX
-#TARGET = X64_SSE3
+#TARGET = X64_AVX
+TARGET = X64_SSE3
 #TARGET = CORTEX_A57
 #TARGET = CORTEX_A15
 #TARGET = CORTEX_A9

--- a/mpc_solvers/d_ip2_soft.c
+++ b/mpc_solvers/d_ip2_soft.c
@@ -339,7 +339,7 @@ exit(1);
 		//update cost function matrices and vectors (box constraints)
 		d_update_hessian_mpc_soft_tv(N, nx, nu, nb, ng, ns, d, 0.0, t, t_inv, lam, lamt, dlam, Qx, qx, Z, z, Zl, zl);
 
-#if 1
+#if 0
 for(ii=0; ii<=N; ii++)
 	d_print_mat(1, 2*pns[ii], Z[ii], 1);
 for(ii=0; ii<=N; ii++)


### PR DESCRIPTION
Hey Gianluca,

I added some information to be printed in the hard constraint test case - I'm printing solver exit status and max run time among all run times. I changed some of the parameters as well, so you may not want to merge this file.

I think the soft one was more important. It was not compiling because of some errors in print function usages, as well as the dependency on files like problem_size.h. I fixed these and noticed it was having runtime errors as well. Then I saw a #if 1 that was leading to a exit(1) in the d_ip2_soft.c file. I assume it was there for debugging purposes. Setting it to #if 0 was enough for the test case to run. I still have other problems that I will report on the Issues section.

Hope this is helpful. Cheers,
Gabriel.